### PR TITLE
Fix main/master branch name in github workflows

### DIFF
--- a/.github/workflows/reusable-update-pre-commit.yml
+++ b/.github/workflows/reusable-update-pre-commit.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: auto-update-${{ github.event.inputs.ref_for_scheduled_build }}
-          base: main
+          base: master
           commit-message: |
             Bump version of pre-commit hooks
 


### PR DESCRIPTION
- Fix pre-commit github workflow auto-update PR failing due to main branch actually being called master (deprecated name)